### PR TITLE
Make RPM source prep version-driven for Jenkins builds

### DIFF
--- a/rpmbuild/SOURCES/prep-ollama.sh
+++ b/rpmbuild/SOURCES/prep-ollama.sh
@@ -1,23 +1,34 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-export GOAMD64=v2
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+spec_file="$script_dir/../SPECS/ollama.spec"
 
-VERSION="0.20.2"
+VERSION="${1:-${VERSION:-$(awk '
+  /^%global[[:space:]]+upstream_version[[:space:]]+/ { print $3; found=1; exit }
+  /^Version:[[:space:]]+/ && !found { print $2; exit }
+' "$spec_file")}}"
 
-rm -f ollama-${VERSION}-vendor.tar.gz
-rm -f ollama-${VERSION}.tar.gz
-rm -f v${VERSION}.tar.gz
+test -n "$VERSION"
 
-wget https://github.com/ollama/ollama/archive/refs/tags/v${VERSION}.tar.gz
-tar -zxvf v${VERSION}.tar.gz
-tar -zcvf ollama-${VERSION}.tar.gz ollama-${VERSION}
+export GOAMD64="${GOAMD64:-v2}"
 
-pushd ollama-${VERSION}
+cd "$script_dir"
+
+rm -f "ollama-${VERSION}-vendor.tar.gz"
+rm -f "ollama-${VERSION}.tar.gz"
+rm -f "v${VERSION}.tar.gz"
+rm -rf "ollama-${VERSION}"
+
+wget -O "v${VERSION}.tar.gz" "https://github.com/ollama/ollama/archive/refs/tags/v${VERSION}.tar.gz"
+tar -zxf "v${VERSION}.tar.gz"
+tar -zcf "ollama-${VERSION}.tar.gz" "ollama-${VERSION}"
+
+pushd "ollama-${VERSION}" >/dev/null
 go mod vendor
-tar -zcvf ../ollama-${VERSION}-vendor.tar.gz vendor
-popd
+tar -zcf "../ollama-${VERSION}-vendor.tar.gz" vendor
+popd >/dev/null
 
-rm -rf ollama-${VERSION}
-rm -f v${VERSION}.tar.gz
+rm -rf "ollama-${VERSION}"
+rm -f "v${VERSION}.tar.gz"

--- a/rpmbuild/SPECS/ollama.spec
+++ b/rpmbuild/SPECS/ollama.spec
@@ -3,13 +3,15 @@
 %bcond_without avx
 
 Name:           ollama
-Version:        0.20.2
+%global upstream_version 0.20.2
+
+Version:        %{upstream_version}
 Release:        1%{?dist}
 Summary:        Tool for running AI models on-premise
 License:        MIT
 URL:            https://ollama.com
-Source:         %{name}-%{version}.tar.gz
-Source1:        %{name}-%{version}-vendor.tar.gz
+Source:         %{name}-%{upstream_version}.tar.gz
+Source1:        %{name}-%{upstream_version}-vendor.tar.gz
 Source2:        %{name}.service
 Source3:        %{name}-user.conf
 Patch0:         ollama-disable-avx512.patch


### PR DESCRIPTION
Prepare the RPM build sources from the spec-defined upstream version instead of a hard-coded release.

This change makes the packaging flow easier to automate from Jenkins by:
- introducing %global upstream_version in ollama.spec
- deriving Version from upstream_version
- updating Source/Source1 to use upstream_version explicitly
- making prep-ollama.sh read the target version from:
  1. the first CLI argument
  2. the VERSION environment variable
  3. the spec file as a fallback
- hardening prep-ollama.sh with bash strict mode
- cleaning up source tarball handling and working-directory behavior

No functional packaging changes are intended for the current version. The goal is to allow CI to build a requested upstream tag without editing the spec or script for every release.