### PR TITLE
Require upstream_version to be provided at build time

### DIFF
--- a/rpmbuild/SPECS/ollama.spec
+++ b/rpmbuild/SPECS/ollama.spec
@@ -2,9 +2,9 @@
 
 %bcond_without avx
 
-Name:           ollama
-%global upstream_version 0.20.2
+%{!?upstream_version:%{error:upstream_version must be defined, e.g. rpmbuild --define 'upstream_version 0.21.0'}}
 
+Name:           ollama
 Version:        %{upstream_version}
 Release:        1%{?dist}
 Summary:        Tool for running AI models on-premise


### PR DESCRIPTION
Stop hard-coding `upstream_version` in ollama.spec and require it to be passed explicitly via rpmbuild.

This prevents the spec from silently resolving Source/Source1 to a stale release when Jenkins prepares newer tarballs and invokes rpmbuild with a different upstream version.

The spec now fails early during parsing if upstream_version is missing, for example:

  rpmbuild -bs --define 'upstream_version 0.21.0' ...

This makes the build input explicit and avoids mismatches between the prepared source tarballs and the version expanded by rpmbuild.